### PR TITLE
Upgrade redis client library to v6

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,8 +54,8 @@
   version = ">=2.0.0"
 
 [[constraint]]
-  name = "gopkg.in/redis.v3"
-  version = ">=3.6.4"
+  name = "github.com/go-redis/redis"
+  version = ">=6.14.0"
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"

--- a/README.md
+++ b/README.md
@@ -161,3 +161,11 @@ To run these tests, you need to pre-setup the AWS credentials (mostly likely in 
 }
 ```
 as data. Then run test with this environment variable and command: `TEST_SECRETS_MANAGER=true go test ./...`.
+
+### Enabling Redis Tests
+
+This is for foundation-go contributors to run redis tests in foundation-go.
+
+Foundation-go has tests that actually connect to a local Redis server. These tests are not run in regular `go test ./...` command.
+
+To run these tests, you need to run a local Redis server *without password* on the port 6379, then run test with this environment variable and command: `TEST_REDIS=true go test ./...`.

--- a/health/redis_check.go
+++ b/health/redis_check.go
@@ -2,7 +2,7 @@ package health
 
 import (
 	"errors"
-	"gopkg.in/redis.v3"
+	"github.com/go-redis/redis"
 	"regexp"
 	"strings"
 	"time"

--- a/health/redis_check_test.go
+++ b/health/redis_check_test.go
@@ -1,14 +1,32 @@
 package health
 
 import (
+	"os"
 	"regexp"
 
+	"github.com/go-redis/redis"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Redis Health Checker", func() {
 	Describe("Check", func() {
+		if os.Getenv("TEST_REDIS") == "true" {
+			It("gets Redis version with a valid client and connection", func() {
+				r := redis.NewClient(&redis.Options{
+					Addr:     ":6379",
+					Password: "",
+					DB:       0,
+				})
+				c := RedisCheck{Name: "testRedis", Client: r}
+				d := c.Check()
+				Expect(d.Name).To(Equal("testRedis"))
+				Expect(d.State.Status).To(Equal(OK))
+				Expect(d.Version).To(MatchRegexp(`\d+\.\d+.\d+`))
+				Expect(d.Revision).To(Equal("00000000"))
+			})
+		}
+
 		It("shows unknown type of Client", func() {
 			c := RedisCheck{Name: "test"}
 			d := c.Check()


### PR DESCRIPTION
Also added a Redis test that is only run with:
`TEST_REDIS=true go test ./...`

- [x] @abdollar 