### PR TITLE
CD-148932:Changing the datatype for "timestamp" field format of ELK log entry to ISO 8601 standard format.

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -27,7 +27,7 @@ type CustomJSONFormatter struct {
 }
 
 func (f *CustomJSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	entry.Data["timestamp"] = entry.Time.UTC().Format("2006-01-02 15:04:05 -0700")
+	entry.Data["timestamp"] = entry.Time.UTC()
 	entry.Data["level"] = entry.Level.String()
 	entry.Data["version"] = f.version
 


### PR DESCRIPTION
**Jira ticket:** https://coupadev.atlassian.net/browse/CD-148932

**Issue:** Kibana is giving error while showing container logs, because the timestamp field is been sent by some of the microservices as string format not recognized as date object by Kibana by default.

**Summary of Change:** Sending timestamp field as "time.Time" in the logs.

**Reviewer:**
- [ ] @johnwu96822 
- [ ] @johnny-lai 
- [ ] @tjackiw 